### PR TITLE
Using binutil's elfedit to patch our custom OSABI

### DIFF
--- a/hermit/usr/benchmarks/Makefile
+++ b/hermit/usr/benchmarks/Makefile
@@ -3,11 +3,6 @@ TARGET=x86_64-hermit
 MAKE = make
 override STRIP_DEBUG = --strip-debug #--strip-unneeded
 KEEP_DEBUG = --only-keep-debug
-OBJCOPY_FLAGS = -j .mboot -j .ktext -j .kdata -j .kbss -j .tbss -j .tdata -j .fini -j .init -j .ctors -j .dtors -j .text -j .data -j .rodata -j .bss -j .percore -j .eh_frame -j .jcr -j .got.plt  -j .preinit_array -j .init_array -j .fini_array -j .gcc_except_table -O binary
-
-# We patch the ELF header with a custom OSABI to be recognized by binfmt_misc
-ELF_OSABI_OFFSET = 7
-ELF_OSABI = "\\x42"
 
 # Set your own cross compiler tool chain prefix here
 CROSSCOMPREFIX = x86_64-hermit-
@@ -25,6 +20,7 @@ OBJCOPY_FOR_TARGET = $(CROSSCOMPREFIX)objcopy
 RANLIB_FOR_TARGET = $(CROSSCOMPREFIX)ranlib
 STRIP_FOR_TARGET = $(CROSSCOMPREFIX)strip
 READELF_FOR_TARGET = $(CROSSCOMPREFIX)readelf
+ELFEDIT_FOR_TARGET = $(CROSSCOMPREFIX)elfedit
 
 # Prettify output
 V = 0
@@ -46,13 +42,9 @@ endif
 	@echo [F90] $@
 	$Q$(FC_FOR_TARGET) -c $(FFLAGS_FOR_TARGET) -o $@ $<
 
-%.bin: %
-	@echo [OBJECT_COPY] $@
-	$Q$(OBJCOPY_FOR_TARGET) $(OBJCOPY_FLAGS) $< $@
-
 default: all
 
-all: stream.bin hg.bin netio.bin RCCE_pingping.bin RCCE_pingpong.bin
+all: stream hg netio RCCE_pingping RCCE_pingpong
 
 stream.o: stream.c
 	@echo [CC] $@
@@ -63,7 +55,7 @@ stream: stream.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -fopenmp -o $@ $<
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 RCCE_pingping: RCCE_pingping.o
@@ -71,7 +63,7 @@ RCCE_pingping: RCCE_pingping.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $< -lircce
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 RCCE_pingpong: RCCE_pingpong.o
@@ -79,7 +71,7 @@ RCCE_pingpong: RCCE_pingpong.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $< -lircce
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 netio.o: netio.c
@@ -91,7 +83,7 @@ netio: netio.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $<
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 hg: hg.o hist.o rdtsc.o run.o init.o opt.o report.o setup.o
@@ -99,16 +91,16 @@ hg: hg.o hist.o rdtsc.o run.o init.o opt.o report.o setup.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $< hist.o rdtsc.o run.o init.o opt.o report.o setup.o
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 clean:
 	@echo Cleaning benchmarks
-	$Q$(RM) stream hg netio RCCE_pingping RCCE_pingpong *.sym *.o *~ *.bin
+	$Q$(RM) stream hg netio RCCE_pingping RCCE_pingpong *.sym *.o *~
 
 veryclean:
 	@echo Propper cleaning benchmarks
-	$Q$(RM)  stream hg RCCE_pingping RCCE_pingpong *.sym *.o *~ *.bin
+	$Q$(RM)  stream hg RCCE_pingping RCCE_pingpong *.sym *.o *~
 
 depend:
 	$Q$(CC_FOR_TARGET) -MM $(CFLAGS_FOR_TARGET) *.c > Makefile.dep

--- a/hermit/usr/openmpbench/Makefile
+++ b/hermit/usr/openmpbench/Makefile
@@ -1,16 +1,9 @@
 include Makefile.defs
 
-# We patch the ELF header with a custom OSABI to be recognized by binfmt_misc
-ELF_OSABI_OFFSET = 7
-ELF_OSABI = "\\x42"
-
 # If CFLAGS_CRAY is empty set it to CFLAGS
 ifeq ($(CFLAGS_CRAY),)
 CFLAGS_CRAY = ${CFLAGS}
 endif
-
-%.bin: %
-	$(OBJCOPY_FOR_TARGET) $(OBJCOPY_FLAGS) $< $@
 
 .c.o:
 	${CC} ${CFLAGS} $(OMPFLAG) -c $*.c 
@@ -21,7 +14,7 @@ ARRAYOBJS = arraybench_$(IDA).o common.o
 TASKOBJS =  taskbench.o common.o 
 SCHEDFLAGS = -DSCHEDBENCH
 
-all:	syncbench.bin schedbench.bin taskbench.bin
+all:	syncbench schedbench taskbench
 
 prog: arraybench_$(IDA) 
 
@@ -41,7 +34,7 @@ common_sched.o:
 
 schedbench: $(SCHEDOBJS)
 	$(CC) -o schedbench  $(LDFLAGS) $(SCHEDOBJS) $(CLOCKOBJS) $(LIBS) -lm
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$(ELFEDIT) --output-osabi HermitCore $@
 
 # Multiple header files due to multiple array sizes, makes header file arraybench_*.h
 arraybench_$(IDA).h: arraybench.h
@@ -57,8 +50,7 @@ arraybench_$(IDA): $(ARRAYOBJS) $(CLOCKOBJS) arraybench.c
 
 taskbench: $(TASKOBJS)
 	$(CC) -o taskbench $(LDFLAGS) $(OMPFLAG) $(TASKOBJS) $(CLOCKOBJS) $(LIBS) -lm 
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
-
+	$(ELFEDIT) --output-osabi HermitCore $@
 clean: 
 	-rm -rf *.o syncbench schedbench arraybench_* taskbench
 

--- a/hermit/usr/openmpbench/Makefile.defs
+++ b/hermit/usr/openmpbench/Makefile.defs
@@ -7,8 +7,8 @@ CC = $(CC_FOR_TARGET)
 CFLAGS = -fopenmp $(CFLAGS_FOR_TARGET) -lm
 LDFLAGS = -fopenmp $(LDFLAGS_FOR_TARGET) -lm
 CPP = $(CPP_FOR_TARGET)
+ELFEDIT = $(ELFEDIT_FOR_TARGET)
 LIBS =
 
 override STRIP_DEBUG = --strip-debug #--strip-unneeded
 KEEP_DEBUG = --only-keep-debug
-OBJCOPY_FLAGS = -j .mboot -j .ktext -j .kdata -j .kbss -j .tbss -j .tdata -j .fini -j .init -j .ctors -j .dtors -j .text -j .data -j .rodata -j .bss -j .percore -j .eh_frame -j .jcr -j .got.plt -j .preinit_array -j .init_array -j .fini_array -j .gcc_except_table -O binary 

--- a/hermit/usr/tests/Makefile
+++ b/hermit/usr/tests/Makefile
@@ -3,11 +3,6 @@ TARGET=x86_64-hermit
 MAKE = make
 override STRIP_DEBUG = --strip-debug #--strip-unneeded
 KEEP_DEBUG = --only-keep-debug
-OBJCOPY_FLAGS = -j .mboot -j .ktext -j .kdata -j .kbss -j .tbss -j .tdata -j .fini -j .init -j .ctors -j .dtors -j .text -j .data -j .rodata -j .bss -j .percore -j .eh_frame -j .jcr -j .got.plt -j .preinit_array -j .init_array -j .fini_array -j .gcc_except_table -O binary
-
-# We patch the ELF header with a custom OSABI to be recognized by binfmt_misc
-ELF_OSABI_OFFSET = 7
-ELF_OSABI = "\\x42"
 
 # Set your own cross compiler tool chain prefix here
 CROSSCOMPREFIX = x86_64-hermit-
@@ -25,6 +20,7 @@ OBJCOPY_FOR_TARGET = $(CROSSCOMPREFIX)objcopy
 RANLIB_FOR_TARGET = $(CROSSCOMPREFIX)ranlib
 STRIP_FOR_TARGET = $(CROSSCOMPREFIX)strip
 READELF_FOR_TARGET = $(CROSSCOMPREFIX)readelf
+ELFEDIT_FOR_TARGET = $(CROSSCOMPREFIX)elfedit
 
 # Prettify output
 V = 0
@@ -46,20 +42,16 @@ endif
 	@echo [F90] $@
 	$Q$(FC_FOR_TARGET) -c $(FFLAGS_FOR_TARGET) -o $@ $<
 
-%.bin: %
-	@echo [OBJECT_COPY] $@
-	$Q$(OBJCOPY_FOR_TARGET) $(OBJCOPY_FLAGS) $< $@
-
 default: all
 
-all: hello.bin hello++.bin thr_hello.bin jacobi.bin hellof.bin RCCE_minimum.bin
+all: hello hello++ thr_hello jacobi hellof RCCE_minimum
 
 hello++: hello++.o
 	@echo [LD] $@
 	$Q$(CXX_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CXXFLAGS_FOR_TARGET) -o $@ $<
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 hello: hello.o
@@ -67,7 +59,7 @@ hello: hello.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $<
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 hellof: hellof.o
@@ -75,7 +67,7 @@ hellof: hellof.o
 	$Q$(FC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(FFLAGS_FOR_TARGET) -o $@ $<
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 jacobi: jacobi.o
@@ -83,7 +75,7 @@ jacobi: jacobi.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $< -lm
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 thr_hello.o: thr_hello.c
@@ -95,7 +87,7 @@ thr_hello: thr_hello.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $< -pthread
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 RCCE_minimum: RCCE_minimum.o
@@ -103,16 +95,16 @@ RCCE_minimum: RCCE_minimum.o
 	$Q$(CC_FOR_TARGET) $(LDFLAGS_FOR_TARGET) $(CFLAGS_FOR_TARGET) -o $@ $< -lircce
 	$Q$(OBJCOPY_FOR_TARGET) $(KEEP_DEBUG) $@ $@.sym
 	$Q$(OBJCOPY_FOR_TARGET) $(STRIP_DEBUG) $@
-	$Qprintf $(ELF_OSABI) | dd of=$@ bs=1 seek=$(ELF_OSABI_OFFSET) count=1 conv=notrunc 2>/dev/null
+	$Q$(ELFEDIT_FOR_TARGET) --output-osabi HermitCore $@
 	$Qchmod a-x $@.sym
 
 clean:
 	@echo Cleaning tests
-	$Q$(RM) hello hello++ hellof jacobi thr_hello RCCE_minimum *.sym *.o *~ *.bin
+	$Q$(RM) hello hello++ hellof jacobi thr_hello RCCE_minimum *.sym *.o *~
 
 veryclean:
 	@echo Propper cleaning tests
-	$Q$(RM) hello hello++ hellof jacobi thr_hello RCCE_minimum *.sym *.o *~ *.bin
+	$Q$(RM) hello hello++ hellof jacobi thr_hello RCCE_minimum *.sym *.o *~
 
 depend:
 	$Q$(CC_FOR_TARGET) -MM $(CFLAGS_FOR_TARGET) *.c > Makefile.dep


### PR DESCRIPTION
Also get rid of obsolete targets (*.bin) and the old `OBJCOPY_FLAGS`