### PR TITLE
Simplified proxy by moving ELF parsing to kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ HermitCore is the result of a research project at RWTH Aachen University and is 
 * Netwide Assembler (NASM)
 * GNU Make, GNU Binutils
 * Tools and libraries to build *linux*, *binutils* and *gcc* (e.g. flex, bison, MPFR library, GMP library, MPC library, ISL library)
-* libelf
 * texinfo
 * Qemu
 


### PR DESCRIPTION
I came up with a nicer way to load ELF binaries:

1. `proxy` writes path of ELF binary in `/sys/hermit/path`
2. Linux parses ELF header and copies relevant segments to `hermit_base[isle]`

This way we can **drop the libelf** dependency and **get rid of a temporary file**.

**Important:** Please merge PR rwth-os/linux#1 before