### PR TITLE
gdb-scripts: fix interpretation of RIP in saved context on stack

### DIFF
--- a/hermit/usr/gdb/hermit/tasks.py
+++ b/hermit/usr/gdb/hermit/tasks.py
@@ -101,7 +101,7 @@ class HermitPs(gdb.Command):
 
             else:
                 # find instruction pointer in saved stack
-                rip_addr = task['last_stack_pointer'] + 20
+                rip_addr = task['last_stack_pointer'] + 25
                 rip_val = int(rip_addr.dereference())
                 # try to resolve a symbol
                 rip_sym = addressToSymbol(rip_val)


### PR DESCRIPTION
Previously, only `<rollback>` would be displayed for not running tasks
because of a misconception of the structure of the saved context.