### PR TITLE
kernel: fix check_timers() and pseudo interrupt stack

### DIFF
--- a/hermit/arch/x86/kernel/entry.asm
+++ b/hermit/arch/x86/kernel/entry.asm
@@ -506,8 +506,8 @@ switch_context:
     pushfq                      ; RFLAGS
     push QWORD 0x08             ; CS
     push QWORD rollback         ; RIP
-    push QWORD 0x00             ; Interrupt number
     push QWORD 0x00edbabe       ; Error code
+    push QWORD 0x00             ; Interrupt number
     push rax
     push rcx
     push rdx

--- a/hermit/kernel/tasks.c
+++ b/hermit/kernel/tasks.c
@@ -766,7 +766,7 @@ void check_timers(void)
 
         // check timers
 	current_tick = get_clock_tick();
-	while (readyqueues[core_id].timers.first && readyqueues[core_id].timers.first->timeout <= current_tick)
+	while (readyqueues[core_id].timers.first && readyqueues[core_id].timers.first->timeout >= current_tick)
 	{
 		task_t* task = readyqueues[core_id].timers.first;
 


### PR DESCRIPTION
This PR fixes 2 bugs in the kernel code:
- the order of error code and interrupt number on the pseudo interrupt stack pushed by `switch_context()` was wrong
- `check_timers()` poped tasks from the timer queue before their deadline was reached