### PR TITLE
Kernel logging facilities

### DIFF
--- a/hermit/arch/x86/kernel/irq.c
+++ b/hermit/arch/x86/kernel/irq.c
@@ -38,6 +38,7 @@
 #include <hermit/tasks.h>
 #include <hermit/errno.h>
 #include <hermit/spinlock.h>
+#include <hermit/logging.h>
 #include <asm/irq.h>
 #include <asm/idt.h>
 #include <asm/isrs.h>
@@ -290,7 +291,7 @@ size_t** irq_handler(struct state *s)
 	size_t** ret = NULL;
 
 	if(BUILTIN_EXPECT(s->int_no >= MAX_HANDLERS, 0)) {
-		kprintf("[%d] Invalid IRQ number %d\n", CORE_ID, s->int_no);
+		LOG_ERROR("Invalid IRQ number %d\n", s->int_no);
 		return NULL;
 	}
 
@@ -303,7 +304,7 @@ size_t** irq_handler(struct state *s)
 	if (handler) {
 		handler(s);
 	} else {
-		kprintf("[%d] Unhandled IRQ %d\n", CORE_ID, s->int_no);
+		LOG_ERROR("Unhandled IRQ %d\n", s->int_no);
 	}
 
 	// Check if timers have expired that would unblock tasks
@@ -324,7 +325,7 @@ size_t** irq_handler(struct state *s)
 		diff = rdtsc() - diff;
 		if (diff > 15000)
 		{
-			kprintf("Core %d, irq_no %d: %lld : %lld\n", CORE_ID, s->int_no, irq_counter[CORE_ID][s->int_no], diff);
+			LOG_INFO("Core %d, irq_no %d: %lld : %lld\n", CORE_ID, s->int_no, irq_counter[CORE_ID][s->int_no], diff);
 		}
 	}
 #endif
@@ -349,7 +350,7 @@ void print_irq_stats(void)
 		for(j=0; j<MAX_HANDLERS; j++)
 		{
 			if (irq_counter[i][j])
-				kprintf("Core %d, IRQ %d: %lld interrupts\n", i, j, irq_counter[i][j]);
+				LOG_INFO("Core %d, IRQ %d: %lld interrupts\n", i, j, irq_counter[i][j]);
 		}
 	}
 }

--- a/hermit/arch/x86/kernel/isrs.c
+++ b/hermit/arch/x86/kernel/isrs.c
@@ -37,6 +37,7 @@
 #include <hermit/stdio.h>
 #include <hermit/tasks.h>
 #include <hermit/errno.h>
+#include <hermit/logging.h>
 #include <asm/irqflags.h>
 #include <asm/isrs.h>
 #include <asm/irq.h>
@@ -209,13 +210,13 @@ static void fault_handler(struct state *s)
 {
 	
 	if (s->int_no < 32)
-		kputs(exception_messages[s->int_no]);
+		LOG_INFO("%s", exception_messages[s->int_no]);
 	else
-		kprintf("Unknown exception %d", s->int_no);
+		LOG_WARNING("Unknown exception %d", s->int_no);
 
-	kprintf(" Exception (%d) on core %d at %#x:%#lx, fs = %#lx, gs = %#lx, error code = 0x%#lx, task id = %u, rflags = %#x\n",
+	LOG_ERROR(" Exception (%d) on core %d at %#x:%#lx, fs = %#lx, gs = %#lx, error code = 0x%#lx, task id = %u, rflags = %#x\n",
 		s->int_no, CORE_ID, s->cs, s->rip, s->fs, s->gs, s->error, per_core(current_task)->id, s->rflags);
-	kprintf("rax %#lx, rbx %#lx, rcx %#lx, rdx %#lx, rbp, %#lx, rsp %#lx rdi %#lx, rsi %#lx, r8 %#lx, r9 %#lx, r10 %#lx, r11 %#lx, r12 %#lx, r13 %#lx, r14 %#lx, r15 %#lx\n",
+	LOG_ERROR("rax %#lx, rbx %#lx, rcx %#lx, rdx %#lx, rbp, %#lx, rsp %#lx rdi %#lx, rsi %#lx, r8 %#lx, r9 %#lx, r10 %#lx, r11 %#lx, r12 %#lx, r13 %#lx, r14 %#lx, r15 %#lx\n",
 		s->rax, s->rbx, s->rcx, s->rdx, s->rbp, s->rsp, s->rdi, s->rsi, s->r8, s->r9, s->r10, s->r11, s->r12, s->r13, s->r14, s->r15);
 
 	apic_eoi(s->int_no);

--- a/hermit/arch/x86/kernel/pci.c
+++ b/hermit/arch/x86/kernel/pci.c
@@ -28,6 +28,7 @@
 #include <hermit/stdio.h>
 #include <hermit/string.h>
 #include <hermit/errno.h>
+#include <hermit/logging.h>
 #include <asm/irqflags.h>
 #include <asm/io.h>
 
@@ -193,7 +194,7 @@ int print_pci_adapters(void)
 
 		if (adapters[bus][slot] != -1) {
 				counter++;
-				kprintf("%d) Vendor ID: 0x%x  Device Id: 0x%x\n",
+				LOG_INFO("%d) Vendor ID: 0x%x  Device Id: 0x%x\n",
 					counter, adapters[bus][slot] & 0xffff, 
 					(adapters[bus][slot] & 0xffff0000) >> 16);
 
@@ -201,7 +202,7 @@ int print_pci_adapters(void)
 				for (i=0; i<PCI_VENTABLE_LEN; i++) {
 					if ((adapters[bus][slot] & 0xffff) ==
 					    (uint32_t)PciVenTable[i].VenId)
-						kprintf("\tVendor is %s\n",
+						LOG_INFO("\tVendor is %s\n",
 							PciVenTable[i].VenShort);
 				}
 
@@ -210,7 +211,7 @@ int print_pci_adapters(void)
 					    (uint32_t)PciDevTable[i].VenId) {
 						if (((adapters[bus][slot] & 0xffff0000) >> 16) ==
 						    PciDevTable[i].DevId) {
-							kprintf
+							LOG_INFO
 							    ("\tChip: %s ChipDesc: %s\n",
 							     PciDevTable[i].Chip,
 							     PciDevTable[i].ChipDesc);

--- a/hermit/arch/x86/kernel/syscall.c
+++ b/hermit/arch/x86/kernel/syscall.c
@@ -30,6 +30,7 @@
 #include <hermit/tasks.h>
 #include <hermit/errno.h>
 #include <hermit/syscall.h>
+#include <hermit/logging.h>
 
 void __startcontext(void);
 
@@ -40,7 +41,7 @@ void makecontext(ucontext_t *ucp, void (*func)(), int argc, ...)
 	if (BUILTIN_EXPECT(!ucp, 0))
 		return;
 
-	//kprintf("sys_makecontext %p, func %p, stack 0x%zx, task %d\n", ucp, func, ucp->uc_stack.ss_sp, per_core(current_task)->id);
+	LOG_DEBUG("sys_makecontext %p, func %p, stack 0x%zx, task %d\n", ucp, func, ucp->uc_stack.ss_sp, per_core(current_task)->id);
 
 	size_t* stack = (size_t*) ((size_t)ucp->uc_stack.ss_sp + ucp->uc_stack.ss_size);
 	stack -= (argc > 6 ? argc - 6 : 0) + 1;
@@ -93,6 +94,6 @@ int swapcontext(ucontext_t *oucp, const ucontext_t *ucp)
 {
 	//TODO: implementation is missing
 
-	kprintf("WARNING: sys_swapcontext is currently not implemented: %p <=> %p\n", oucp, ucp);
+	LOG_WARNING("sys_swapcontext is currently not implemented: %p <=> %p\n", oucp, ucp);
 	return -ENOSYS;
 }

--- a/hermit/arch/x86/kernel/tasks.c
+++ b/hermit/arch/x86/kernel/tasks.c
@@ -34,6 +34,7 @@
 #include <hermit/memory.h>
 #include <hermit/vma.h>
 #include <hermit/rcce.h>
+#include <hermit/logging.h>
 #include <asm/tss.h>
 #include <asm/page.h>
 
@@ -88,8 +89,8 @@ int create_default_frame(task_t* task, entry_point_t ep, void* arg, uint32_t cor
 	if (BUILTIN_EXPECT(!task->stack, 0))
 		return -EINVAL;
 
-	kprintf("Task %d uses memory region [%p - %p] as stack\n", task->id, task->stack, (char*) task->stack + KERNEL_STACK_SIZE - 1);
-	kprintf("Task %d uses memory region [%p - %p] as IST1\n", task->id, task->ist_addr, (char*) task->ist_addr + KERNEL_STACK_SIZE - 1);
+	LOG_INFO("Task %d uses memory region [%p - %p] as stack\n", task->id, task->stack, (char*) task->stack + KERNEL_STACK_SIZE - 1);
+	LOG_INFO("Task %d uses memory region [%p - %p] as IST1\n", task->id, task->ist_addr, (char*) task->ist_addr + KERNEL_STACK_SIZE - 1);
 
 	memset(task->stack, 0xCD, DEFAULT_STACK_SIZE);
 

--- a/hermit/arch/x86/kernel/timer.c
+++ b/hermit/arch/x86/kernel/timer.c
@@ -32,6 +32,7 @@
 #include <hermit/tasks.h>
 #include <hermit/errno.h>
 #include <hermit/spinlock.h>
+#include <hermit/logging.h>
 #include <asm/irq.h>
 #include <asm/irqflags.h>
 #include <asm/io.h>
@@ -95,7 +96,7 @@ static void timer_handler(struct state *s)
 	 * display a message on the screen
 	 */
 	if (timer_ticks % TIMER_FREQ == 0) {
-		kprintf("One second has passed %d\n", CORE_ID);
+		LOG_INFO("One second has passed %d\n", CORE_ID);
 	}
 #endif
 }

--- a/hermit/arch/x86/kernel/uart.c
+++ b/hermit/arch/x86/kernel/uart.c
@@ -31,6 +31,7 @@
 #include <hermit/string.h>
 #include <hermit/ctype.h>
 #include <hermit/vma.h>
+#include <hermit/logging.h>
 #include <asm/page.h>
 #include <asm/io.h>
 #include <asm/page.h>
@@ -298,11 +299,11 @@ Lsuccess:
 	irq_install_handler(32+pci_info.irq, uart_handler);
 	if (pci_info.type[0]) {
 		mmio = 0;
-		kprintf("UART uses io address 0x%x\n", iobase);
+		LOG_INFO("UART uses io address 0x%x\n", iobase);
 	} else {
 		mmio = 1;
 		page_map(iobase & PAGE_MASK, iobase & PAGE_MASK, 1, PG_GLOBAL | PG_ACCESSED | PG_DIRTY | PG_RW | PG_PCD);
-		kprintf("UART uses mmio address 0x%x\n", iobase);
+		LOG_INFO("UART uses mmio address 0x%x\n", iobase);
 		vma_add(iobase, iobase + PAGE_SIZE, VMA_READ|VMA_WRITE);
 	}
 

--- a/hermit/drivers/net/e1000.c
+++ b/hermit/drivers/net/e1000.c
@@ -31,6 +31,7 @@
 #include <hermit/string.h>
 #include <hermit/processor.h>
 #include <hermit/mailbox.h>
+#include <hermit/logging.h>
 #include <asm/page.h>
 #include <asm/io.h>
 #include <asm/irq.h>
@@ -422,7 +423,7 @@ err_t e1000if_init(struct netif* netif)
 	tmp32 &= ~(E1000_CTRL_VME|E1000_CTRL_FD|E1000_CTRL_ILOS|E1000_CTRL_PHY_RST|E1000_CTRL_LRST|E1000_CTRL_FRCSPD);
 	e1000_write(e1000if->bar0, E1000_CTRL, tmp32 | E1000_CTRL_SLU | E1000_CTRL_ASDE);
 	e1000_flush(e1000if->bar0);
-	kprintf("e1000if_init: Device Control Register 0x%x\n", e1000_read(e1000if->bar0, E1000_CTRL));
+	LOG_INFO("e1000if_init: Device Control Register 0x%x\n", e1000_read(e1000if->bar0, E1000_CTRL));
 
 	/* make sure transmits are disabled while setting up the descriptors */
 	tmp32 = e1000_read(e1000if->bar0, E1000_TCTL);

--- a/hermit/drivers/net/util.c
+++ b/hermit/drivers/net/util.c
@@ -31,6 +31,7 @@
  */
 
 #include <hermit/stdio.h>
+#include <hermit/logging.h>
 #include "util.h"
 
 inline int isprint(unsigned char e)
@@ -47,19 +48,19 @@ void hex_dump(unsigned n, const unsigned char *buf)
 
 	while (n-- > 0)
 	{
-		kprintf("%02X ", *buf++);
+		LOG_SAME_LINE(LOG_LEVEL_INFO, "%02X ", *buf++);
 		on_this_line += 1;
 
 		if (on_this_line == 16 || n == 0)
 		{
 			int i;
 
-			kputs(" ");
+			LOG_SAME_LINE(LOG_LEVEL_INFO, " ");
 			for (i = on_this_line; i < 16; i++)
-				kputs(" ");
+				LOG_SAME_LINE(LOG_LEVEL_INFO, " ");
 			for (i = on_this_line; i > 0; i--)
-				kputchar(isprint(buf[-i]) ? buf[-i] : '.');
-			kputs("\n");
+				LOG_SAME_LINE(LOG_LEVEL_INFO, "%c", isprint(buf[-i]) ? buf[-i] : '.');
+			LOG_SAME_LINE(LOG_LEVEL_INFO, "\n");
 			on_this_line = 0;
 		}
 	}

--- a/hermit/include/hermit/logging.h
+++ b/hermit/include/hermit/logging.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016, Daniel Krebs, RWTH Aachen University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the University nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __HERMIT_LOGGING_H__
+#define __HERMIT_LOGGING_H__
+
+#include <hermit/time.h>
+#include <hermit/syscall.h>
+#include <hermit/stddef.h>
+
+enum {
+	LOG_LEVEL_DISABLED = 0,
+	LOG_LEVEL_ERROR,
+	LOG_LEVEL_WARNING,
+	LOG_LEVEL_INFO,
+	LOG_LEVEL_DEBUG,
+	LOG_LEVEL_VERBOSE
+};
+
+#define LOG_LEVEL_ERROR_PREFIX		"ERROR"
+#define LOG_LEVEL_WARNING_PREFIX	"WARNING"
+#define LOG_LEVEL_INFO_PREFIX		"INFO"
+#define LOG_LEVEL_DEBUG_PREFIX		"DEBUG"
+#define LOG_LEVEL_VERBOSE_PREFIX	"VERBOSE"
+
+#ifndef LOG_LEVEL
+    #define LOG_LEVEL LOG_LEVEL_INFO
+#endif
+
+// Gratefully taken from Leushenko @ http://stackoverflow.com/a/19017591
+#define CONC(a,b) a##_##b
+#define IF(c, t, e) CONC(IF, c)(t, e)
+#define IF_0(t, e) e
+#define IF_1(t, e) t
+
+#define __LOG_FUNCTION(...) kprintf(__VA_ARGS__)
+
+// [timestamp][core:task][level] ...
+#define __LOG_FORMAT_VERBOSE(level, fmt, ...) \
+	"[%d.%03d][%d:%d][" CONC(level, PREFIX) "] " fmt, \
+	(get_uptime() / 1000), (get_uptime() % 1000), \
+	CORE_ID, sys_getpid(), \
+	##__VA_ARGS__
+
+// don't add any formatting
+#define __LOG_FORMAT_PASS(level, fmt, ...) fmt, ##__VA_ARGS__
+
+// The compiler will optimize the if clause away since the condition can be
+// evaluated at compile-time
+#define __LOG(level, formatter, ...) do {	\
+	if(LOG_LEVEL >= level) {	\
+	    __LOG_FUNCTION(formatter(level, __VA_ARGS__));	\
+	}	\
+} while(0)
+
+#define LOG_ERROR(...)		__LOG(LOG_LEVEL_ERROR, __LOG_FORMAT_VERBOSE, __VA_ARGS__)
+#define LOG_WARNING(...)	__LOG(LOG_LEVEL_WARNING, __LOG_FORMAT_VERBOSE, __VA_ARGS__)
+#define LOG_INFO(...)		__LOG(LOG_LEVEL_INFO, __LOG_FORMAT_VERBOSE, __VA_ARGS__)
+#define LOG_DEBUG(...)		__LOG(LOG_LEVEL_DEBUG, __LOG_FORMAT_VERBOSE, __VA_ARGS__)
+#define LOG_VERBOSE(...)	__LOG(LOG_LEVEL_VERBOSE, __LOG_FORMAT_VERBOSE, __VA_ARGS__)
+
+// No formatting will be applied, so this can be used to expand the previous
+// line.
+#define LOG_SAME_LINE(level, ...)	__LOG(level, __LOG_FORMAT_PASS, __VA_ARGS__)
+
+#endif // __HERMIT_LOGGING_H__

--- a/hermit/include/hermit/time.h
+++ b/hermit/include/hermit/time.h
@@ -81,6 +81,10 @@ static inline uint64_t get_clock_tick(void)
  */
 static inline void sleep(unsigned int sec) { timer_wait(sec*TIMER_FREQ); }
 
+/** @brief Get milliseconds since system boot
+ */
+static inline uint64_t get_uptime() { return (get_clock_tick() * 1000) / TIMER_FREQ; }
+
 static inline int timer_deadline(uint32_t t) { return apic_timer_deadline(t); }
 
 static inline void timer_disable(void) { apic_disable_timer(); }

--- a/hermit/kernel/main.c
+++ b/hermit/kernel/main.c
@@ -36,6 +36,7 @@
 #include <hermit/memory.h>
 #include <hermit/spinlock.h>
 #include <hermit/rcce.h>
+#include <hermit/logging.h>
 #include <asm/irq.h>
 #include <asm/page.h>
 #include <asm/uart.h>
@@ -106,7 +107,7 @@ static int foo(void* arg)
 	int i;
 
 	for(i=0; i<5; i++) {
-		kprintf("hello from %s\n", (char*) arg);
+		LOG_INFO("hello from %s\n", (char*) arg);
 		sleep(1);
 	}
 
@@ -146,7 +147,7 @@ static void print_status(void)
 	static spinlock_t status_lock = SPINLOCK_INIT;
 
 	spinlock_lock(&status_lock);
-	kprintf("CPU %d of isle %d is now online (CR0 0x%zx, CR4 0x%zx)\n", CORE_ID, isle, read_cr0(), read_cr4());
+	LOG_INFO("CPU %d of isle %d is now online (CR0 0x%zx, CR4 0x%zx)\n", CORE_ID, isle, read_cr0(), read_cr4());
 	spinlock_unlock(&status_lock);
 }
 
@@ -154,7 +155,7 @@ static void tcpip_init_done(void* arg)
 {
 	sys_sem_t* sem = (sys_sem_t*)arg;
 
-	kprintf("LwIP's tcpip thread has task id %d\n", per_core(current_task)->id);
+	LOG_INFO("LwIP's tcpip thread has task id %d\n", per_core(current_task)->id);
 
 	sys_sem_signal(sem);
 }
@@ -175,7 +176,7 @@ static int init_netifs(void)
 
 	tcpip_init(tcpip_init_done, &sem);
 	sys_sem_wait(&sem);
-	kprintf("TCP/IP initialized.\n");
+	LOG_INFO("TCP/IP initialized.\n");
 	sys_sem_free(&sem);
 
 	if (!is_single_kernel())
@@ -203,7 +204,7 @@ static int init_netifs(void)
 		if ((err = netifapi_netif_add(&default_netif, &ipaddr, &netmask, &gw, NULL, mmnif_init, ip_input)) != ERR_OK)
 #endif
 		{
-			kprintf("Unable to add the intra network interface: err = %d\n", err);
+			LOG_ERROR("Unable to add the intra network interface: err = %d\n", err);
 			return -ENODEV;
 		}
 
@@ -229,7 +230,7 @@ static int init_netifs(void)
 		if ((err = netifapi_netif_add(&default_netif, &ipaddr, &netmask, &gw, NULL, e1000if_init, ethernet_input)) == ERR_OK)
 			goto success;
 
-		kprintf("Unable to add the network interface: err = %d\n", err);
+		LOG_ERROR("Unable to add the network interface: err = %d\n", err);
 
 		return -ENODEV;
 
@@ -237,7 +238,7 @@ success:
 		netifapi_netif_set_default(&default_netif);
 
 #if USE_DHCP
-		kprintf("Starting DHCPD...\n");
+		LOG_INFO("Starting DHCPD...\n");
 		netifapi_dhcp_start(&default_netif);
 
 		int mscnt = 0;
@@ -273,7 +274,7 @@ success:
 
 int network_shutdown(void)
 {
-	kputs("Shutdown LwIP\n");
+	LOG_INFO("Shutdown LwIP\n");
 
 	if (libc_sd >= 0) {
 		int s = libc_sd;
@@ -329,7 +330,7 @@ static int init_rcce(void)
 	rcce_lock = (islelock_t*) addr;
 	rcce_mpb = (rcce_mpb_t*) (addr + CACHE_LINE*(RCCE_MAXNP+1));
 
-	kprintf("Map rcce_lock at %p and rcce_mpb at %p\n", rcce_lock, rcce_mpb);
+	LOG_INFO("Map rcce_lock at %p and rcce_mpb at %p\n", rcce_lock, rcce_mpb);
 
 	return 0;
 }
@@ -354,7 +355,7 @@ static void lock_test(void)
 
 	end = rdtsc();
 
-	kprintf("locks %lld (iterations %d)\n", end-start, i);
+	LOG_INFO("locks %lld (iterations %d)\n", end-start, i);
 
 	start = rdtsc();
 
@@ -367,7 +368,7 @@ static void lock_test(void)
 
 	end = rdtsc();
 
-	kprintf("sem %lld (iterations %d)\n", end-start, i);
+	LOG_INFO("sem %lld (iterations %d)\n", end-start, i);
 }
 #endif
 
@@ -387,14 +388,14 @@ static int initd(void* arg)
 	char** argv = NULL;
 	char **environ = NULL;
 
-	kputs("Initd is running\n");
+	LOG_INFO("Initd is running\n");
 
 	// setup heap
 	if (!curr_task->heap)
 		curr_task->heap = (vma_t*) kmalloc(sizeof(vma_t));
 
 	if (BUILTIN_EXPECT(!curr_task->heap, 0)) {
-		kprintf("load_task: heap is missing!\n");
+		LOG_ERROR("load_task: heap is missing!\n");
 		return -ENOMEM;
 	}
 
@@ -427,7 +428,7 @@ static int initd(void* arg)
 
 	s = lwip_socket(PF_INET , SOCK_STREAM , 0);
 	if (s < 0) {
-		kprintf("socket failed: %d\n", server);
+		LOG_ERROR("socket failed: %d\n", server);
 		return -1;
 	}
 
@@ -439,31 +440,31 @@ static int initd(void* arg)
 
 	if ((err = lwip_bind(s, (struct sockaddr *) &server, sizeof(server))) < 0)
 	{
-		kprintf("bind failed: %d\n", errno);
+		LOG_ERROR("bind failed: %d\n", errno);
 		lwip_close(s);
 		return -1;
 	}
 
 	if ((err = lwip_listen(s, 2)) < 0)
 	{
-		kprintf("listen failed: %d\n", errno);
+		LOG_ERROR("listen failed: %d\n", errno);
 		lwip_close(s);
 		return -1;
 	}
 
 	len = sizeof(struct sockaddr_in);
 
-	kprintf("Boot time: %d ms\n", (get_clock_tick() * 1000) / TIMER_FREQ);
-	kputs("TCP server is listening.\n");
+	LOG_INFO("Boot time: %d ms\n", (get_clock_tick() * 1000) / TIMER_FREQ);
+	LOG_INFO("TCP server is listening.\n");
 
 	if ((c = lwip_accept(s, (struct sockaddr *)&client, (socklen_t*)&len)) < 0)
 	{
-		kprintf("accept faild: %d\n", errno);
+		LOG_ERROR("accept faild: %d\n", errno);
 		lwip_close(s);
 		return -1;
 	}
 
-	kputs("Establish IP connection\n");
+	LOG_INFO("Establish IP connection\n");
 
 	lwip_setsockopt(c, SOL_SOCKET, SO_RCVBUF, (char *) &sobufsize, sizeof(sobufsize));
 	lwip_setsockopt(c, SOL_SOCKET, SO_SNDBUF, (char *) &sobufsize, sizeof(sobufsize));
@@ -476,7 +477,7 @@ static int initd(void* arg)
 	lwip_read(c, &magic, sizeof(magic));
 	if (magic != HERMIT_MAGIC)
 	{
-		kprintf("Invalid magic number %d\n", magic);
+		LOG_ERROR("Invalid magic number %d\n", magic);
 		lwip_close(c);
 		return -1;
 	}
@@ -577,20 +578,20 @@ int hermit_main(void)
 	hermit_init();
 	system_calibration(); // enables also interrupts
 
-	kprintf("This is Hermit %s, build date %u\n", VERSION, &__DATE__);
-	kprintf("Isle %d of %d possible isles\n", isle, possible_isles);
-	kprintf("Kernel starts at %p and ends at %p\n", &kernel_start, &kernel_end);
-	kprintf("TLS image starts at %p and ends at %p\n", &tls_start, &tls_end);
-	kprintf("BBS starts at %p and ends at %p\n", &hbss_start, &kernel_end);
-	kprintf("Per core data starts at %p and ends at %p\n", &percore_start, &percore_end);
-	kprintf("Per core size 0x%zx\n", (size_t) &percore_end0 - (size_t) &percore_start);
-	kprintf("Processor frequency: %u MHz\n", get_cpu_frequency());
-	kprintf("Total memory: %zd MiB\n", atomic_int64_read(&total_pages) * PAGE_SIZE / (1024ULL*1024ULL));
-	kprintf("Current allocated memory: %zd KiB\n", atomic_int64_read(&total_allocated_pages) * PAGE_SIZE / 1024ULL);
-	kprintf("Current available memory: %zd MiB\n", atomic_int64_read(&total_available_pages) * PAGE_SIZE / (1024ULL*1024ULL));
-	kprintf("Core %d is the boot processor\n", boot_processor);
+	LOG_INFO("This is Hermit %s, build date %u\n", VERSION, &__DATE__);
+	LOG_INFO("Isle %d of %d possible isles\n", isle, possible_isles);
+	LOG_INFO("Kernel starts at %p and ends at %p\n", &kernel_start, &kernel_end);
+	LOG_INFO("TLS image starts at %p and ends at %p\n", &tls_start, &tls_end);
+	LOG_INFO("BBS starts at %p and ends at %p\n", &hbss_start, &kernel_end);
+	LOG_INFO("Per core data starts at %p and ends at %p\n", &percore_start, &percore_end);
+	LOG_INFO("Per core size 0x%zx\n", (size_t) &percore_end0 - (size_t) &percore_start);
+	LOG_INFO("Processor frequency: %u MHz\n", get_cpu_frequency());
+	LOG_INFO("Total memory: %zd MiB\n", atomic_int64_read(&total_pages) * PAGE_SIZE / (1024ULL*1024ULL));
+	LOG_INFO("Current allocated memory: %zd KiB\n", atomic_int64_read(&total_allocated_pages) * PAGE_SIZE / 1024ULL);
+	LOG_INFO("Current available memory: %zd MiB\n", atomic_int64_read(&total_available_pages) * PAGE_SIZE / (1024ULL*1024ULL));
+	LOG_INFO("Core %d is the boot processor\n", boot_processor);
 	if (hbmem_base)
-		kprintf("Found high bandwidth memory at 0x%zx (size 0x%zx)\n", hbmem_base, hbmem_size);
+		LOG_INFO("Found high bandwidth memory at 0x%zx (size 0x%zx)\n", hbmem_base, hbmem_size);
 
 #if 0
 	print_pci_adapters();

--- a/hermit/kernel/main.c
+++ b/hermit/kernel/main.c
@@ -58,7 +58,7 @@
 #include <net/e1000.h>
 
 #define HERMIT_PORT	0x494E
-#define HEMRIT_MAGIC	0x7E317
+#define HERMIT_MAGIC	0x7E317
 
 // set to one if the single-kernel version should use a DHCP server
 #define USE_DHCP	1
@@ -474,7 +474,7 @@ static int initd(void* arg)
 
 	magic = 0;
 	lwip_read(c, &magic, sizeof(magic));
-	if (magic != HEMRIT_MAGIC)
+	if (magic != HERMIT_MAGIC)
 	{
 		kprintf("Invalid magic number %d\n", magic);
 		lwip_close(c);

--- a/hermit/kernel/syscall.c
+++ b/hermit/kernel/syscall.c
@@ -36,6 +36,7 @@
 #include <hermit/rcce.h>
 #include <hermit/memory.h>
 #include <hermit/signal.h>
+#include <hermit/logging.h>
 #include <sys/uio.h>
 #include <sys/poll.h>
 
@@ -237,7 +238,7 @@ ssize_t sys_sbrk(ssize_t incr)
 	static spinlock_t heap_lock = SPINLOCK_INIT;
 
 	if (BUILTIN_EXPECT(!heap, 0)) {
-		kprintf("sys_sbrk: missing heap!\n");
+		LOG_ERROR("sys_sbrk: missing heap!\n");
 		do_abort();
 	}
 
@@ -508,7 +509,7 @@ int sys_rcce_init(int session_id)
 out:
 	islelock_unlock(rcce_lock);
 
-	kprintf("Create MPB for session %d at 0x%zx, using of slot %d\n", session_id, paddr, i);
+	LOG_INFO("Create MPB for session %d at 0x%zx, using of slot %d\n", session_id, paddr, i);
 
 	return err;
 }
@@ -538,7 +539,7 @@ size_t sys_rcce_malloc(int session_id, int ue)
 		}
 	} while((i >= MAX_RCCE_SESSIONS) && (counter < 120));
 
-	//kprintf("i = %d, counter = %d, max %d\n", i, counter, MAX_RCCE_SESSIONS);
+	LOG_DEBUG("i = %d, counter = %d, max %d\n", i, counter, MAX_RCCE_SESSIONS);
 
 	// create new session
 	if (i >= MAX_RCCE_SESSIONS)
@@ -553,7 +554,7 @@ size_t sys_rcce_malloc(int session_id, int ue)
 		goto out;
 	}
 
-	kprintf("Map MPB of session %d at 0x%zx, using of slot %d, isle %d\n", session_id, vaddr, i, ue);
+	LOG_INFO("Map MPB of session %d at 0x%zx, using of slot %d, isle %d\n", session_id, vaddr, i, ue);
 
 	if (isle == ue)
 		memset((void*)vaddr, 0x0, RCCE_MPB_SIZE);
@@ -561,7 +562,7 @@ size_t sys_rcce_malloc(int session_id, int ue)
 	return vaddr;
 
 out:
-	kprintf("Didn't find a valid MPB for session %d, isle %d\n", session_id, ue);
+	LOG_ERROR("Didn't find a valid MPB for session %d, isle %d\n", session_id, ue);
 
 	return 0;
 }

--- a/hermit/mm/hbmemory.c
+++ b/hermit/mm/hbmemory.c
@@ -31,6 +31,7 @@
 #include <hermit/string.h>
 #include <hermit/spinlock.h>
 #include <hermit/memory.h>
+#include <hermit/logging.h>
 
 #include <asm/atomic.h>
 #include <asm/page.h>
@@ -85,7 +86,7 @@ size_t hbmem_get_pages(size_t npages)
 		curr = curr->next;
 	}
 out:
-	//kprintf("get_pages: ret 0%llx, curr->start 0x%llx, curr->end 0x%llx\n", ret, curr->start, curr->end);
+	LOG_DEBUG("get_pages: ret 0%llx, curr->start 0x%llx, curr->end 0x%llx\n", ret, curr->start, curr->end);
 
 	spinlock_unlock(&list_lock);
 
@@ -164,7 +165,7 @@ int hbmemory_init(void)
 	init_list.start = hbmem_base;
 	init_list.end = hbmem_base + hbmem_size;
 
-	kprintf("free list for hbmem starts at 0x%zx, limit 0x%zx\n", init_list.start, init_list.end);
+	LOG_INFO("free list for hbmem starts at 0x%zx, limit 0x%zx\n", init_list.start, init_list.end);
 
 	return 0;
 }

--- a/hermit/mm/malloc.c
+++ b/hermit/mm/malloc.c
@@ -33,6 +33,7 @@
 #include <hermit/malloc.h>
 #include <hermit/spinlock.h>
 #include <hermit/memory.h>
+#include <hermit/logging.h>
 #include <asm/page.h>
 
 /// A linked list for each binary size exponent
@@ -120,14 +121,14 @@ void buddy_dump(void)
 		int exp = i+BUDDY_MIN;
 
 		if (buddy_lists[i])
-			kprintf("buddy_list[%u] (exp=%u, size=%lu bytes):\n", i, exp, 1<<exp);
+			LOG_INFO("buddy_list[%u] (exp=%u, size=%lu bytes):\n", i, exp, 1<<exp);
 
 		for (buddy=buddy_lists[i]; buddy; buddy=buddy->next) {
-			kprintf("  %p -> %p \n", buddy, buddy->next);
+			LOG_INFO("  %p -> %p \n", buddy, buddy->next);
 			free += 1<<exp;
 		}
 	}
-	kprintf("free buddies: %lu bytes\n", free);
+	LOG_INFO("free buddies: %lu bytes\n", free);
 }
 
 void* palloc(size_t sz, uint32_t flags)
@@ -136,7 +137,7 @@ void* palloc(size_t sz, uint32_t flags)
 	uint32_t npages = PAGE_FLOOR(sz) >> PAGE_BITS;
 	int err;
 
-	//kprintf("palloc(%lu) (%lu pages)\n", sz, npages);
+	LOG_DEBUG("palloc(%lu) (%lu pages)\n", sz, npages);
 
 	// get free virtual address space
 	viraddr = vma_alloc(PAGE_FLOOR(sz), flags);
@@ -173,7 +174,7 @@ void* create_stack(size_t sz)
 	uint32_t npages = PAGE_FLOOR(sz) >> PAGE_BITS;
 	int err;
 
-	//kprintf("create_stack(0x%zx) (%lu pages)\n", DEFAULT_STACK_SIZE, npages);
+	LOG_DEBUG("create_stack(0x%zx) (%lu pages)\n", DEFAULT_STACK_SIZE, npages);
 
 	if (BUILTIN_EXPECT(!sz, 0))
 		return NULL;
@@ -211,7 +212,7 @@ int destroy_stack(void* viraddr, size_t sz)
 	size_t phyaddr;
 	uint32_t npages = PAGE_FLOOR(sz) >> PAGE_BITS;
 
-	//kprintf("destroy_stack(0x%zx) (size 0x%zx)\n", viraddr, DEFAULT_STACK_SIZE);
+	LOG_DEBUG("destroy_stack(0x%zx) (size 0x%zx)\n", viraddr, DEFAULT_STACK_SIZE);
 
 	if (BUILTIN_EXPECT(!viraddr, 0))
 		return -EINVAL;
@@ -250,7 +251,7 @@ void* kmalloc(size_t sz)
 	buddy->prefix.magic = BUDDY_MAGIC;
 	buddy->prefix.exponent = exp;
 
-	//kprintf("kmalloc(%lu) = %p\n", sz, buddy+1);
+	LOG_DEBUG("kmalloc(%lu) = %p\n", sz, buddy+1);
 
 	// pointer arithmetic: we hide the prefix
 	return buddy+1;
@@ -261,7 +262,7 @@ void kfree(void *addr)
 	if (BUILTIN_EXPECT(!addr, 0))
 		return;
 
-	//kprintf("kfree(%lu)\n", addr);
+	LOG_DEBUG("kfree(%lu)\n", addr);
 
 	buddy_t* buddy = (buddy_t*) addr - 1; // get prefix
 


### PR DESCRIPTION
This PR provides level based logging throughout the HermitCore kernel. Instead of using `kprintf(...)` you can now use e.g. `LOG_ERROR(...)` to report errors or `LOG_INFO(...)` to output normal logging information.

The default log level is `INFO`, so `LOG_ERROR`, `LOG_WARNING` and `LOG_INFO` will be output, whereas `LOG_DEBUG` and `LOG_VERBOSE` will be suppressed. The hierarchy is as follows:

DISABLED < ERROR < WARNING < INFO < DEBUG < VERBOSE

To set the log level (per file) you need undefine and then redefine it:

```c
// as verbose as possible, includes all log levels
#undef LOG_LEVEL
#define LOG_LEVEL LOG_LEVEL_VERBOSE
```

The default log format includes a timestamp (system uptime in seconds), the current core ID, the current task ID and the log level. A sample output can look like this:

```
to 192.168.28.1
[0.030][1:1][INFO] Initialize mmnif
[0.030][1:1][INFO] mmnif_init() : size of mm_rx_buffer_t : 1040
[0.030][1:1][INFO] map header 0x7e8000 at 0x7e8000
[0.030][1:1][INFO] map heap 0x7eb000 at 0x7eb000
[0.030][1:1][INFO] map isle_locks 0x7e7000 at 0xea000
[0.030][1:1][INFO] mmnif init complete
netif: added interface mm IP addr 192.168.28.2 netmask 255.255.255.0 gw 192.168.28.1
netif: setting default interface mm
[0.030][1:1][INFO] Map rcce_lock at 0xeb000 and rcce_mpb at 0xeb240
[0.030][1:1][INFO] Boot time: 30 ms
[0.030][1:1][INFO] TCP server is listening.
[0.030][1:1][INFO] Establish IP connection
[0.210][1:1][INFO] Terminate task: 1, return value 0
[0.210][1:0][INFO] Release stack at 0xd1000
[0.210][1:0][INFO] Receive shutdown interrupt
[0.210][1:0][INFO] Try to shutdown HermitCore
[0.210][1:0][INFO] Shutdown LwIP
[0.210][1:0][INFO] Disable APIC timer
[0.210][1:0][INFO] Disable APIC
[0.210][1:0][INFO] Core 1, IRQ 7: 1 interrupts
[0.210][1:0][INFO] Core 1, IRQ 14: 1 interrupts
[0.210][1:0][INFO] Core 1, IRQ 113: 1 interrupts
[0.210][1:0][INFO] Core 1, IRQ 122: 34 interrupts
[0.210][1:0][INFO] System goes down...
[0.000][1:0][INFO] PAT use per default writeback.
[0.000][1:0][INFO] MTRR is enabled.
[0.000][1:0][INFO] Fixed-range MTRR is enabled.
[0.000][1:0][INFO] MTRR used per default writeback.
[0.000][1:0][INFO] mb_info: 0x0
[0.000][1:0][INFO] memory_init: base 0x7be00000, image_size 0xa83ab0, limit 0xbbe00000
[0.000][1:0][INFO] free list starts at 0x7ca00000, limit 0xbbe00000
[0.000][1:0][INFO] vma_init: reserve vma region 0x800000 - 0x1400000
[0.000][1:0][INFO] Found EBDA at 0x9fc0!
[0.000][1:0][INFO] Found MP config table at 0xf6af0
[0.000][1:0][INFO] System uses Multiprocessing Specification 1.4
[0.000][1:0][INFO] MP features 1: 0
[0.000][1:0][INFO] Virtual-Wire mode implemented
[0.000][1:0][INFO] Found IOAPIC at 0xfec00000
[0.000][1:0][INFO] Found 10 cores
[0.000][1:0][INFO] Found APIC at 0xfee00000
[0.000][1:0][INFO] Found and enable X2APIC
[0.000][1:0][INFO] Maximum LVT Entry: 0x5
[0.000][1:0][INFO] APIC Version: 0x14
[0.000][1:0][INFO] EOI-broadcast: available
[0.000][1:0][INFO] Boot processor 1 (ID 1)
[0.000][1:0][INFO] APIC calibration determined an ICR of 0x98960c
[0.000][1:0][INFO] This is Hermit 1b5e95-dirty, build date 11694952
[0.000][1:0][INFO] Isle 0 of 2 possible isles
[0.000][1:0][INFO] Kernel starts at 0x800000 and ends at 0x1283ab0
[0.000][1:0][INFO] TLS image starts at 0xb31140 and ends at 0xb31140
[0.000][1:0][INFO] BBS starts at 0xb31140 and ends at 0x1283ab0
[0.000][1:0][INFO] Per core data starts at 0xb2f140 and ends at 0xb31140
[0.000][1:0][INFO] Per core size 0x40
[0.000][1:0][INFO] Processor frequency: 2394 MHz
[0.000][1:0][INFO] Total memory: 1024 MiB
[0.000][1:0][INFO] Current allocated memory: 12352 KiB
[0.000][1:0][INFO] Current available memory: 1011 MiB
[0.000][1:0][INFO] Core 1 is the boot processor
[0.000][1:0][INFO] CPU 1 of isle 0 is now online (CR0 0x8004003b, CR4 0x506a0)
[0.000][1:0][INFO] Task 1 use use the memory region [0xd1000 - 0xd2fff] as stack
[0.000][1:0][INFO] Task 1 use use the memory region [0xe3000 - 0xe4fff] as IST1
[0.000][1:0][INFO] start new task 1 on core 1 with stack address 0xd1000
[0.030][1:1][INFO] Initd is running
netif_set_ipaddr: netif address being changed
netif: IP address of interface ?? set to 127.0.0.1
netif: netmask of interface ?? set to 255.0.0.0
netif: GW address of interface ?? set to 127.0.0.1
netif: added interface lo IP addr 127.0.0.1 netmask 255.0.0.0 gw 127.0.0.1
[0.030][1:1][INFO] Task 2 use use the memory region [0xf8000 - 0xf9fff] as stack
[0.030][1:1][INFO] Task 2 use use the memory region [0xe7000 - 0xe8fff] as IST1
[0.030][1:1][INFO] start new task 2 on core 1 with stack address 0xf8000
sys_thread_new: create_kernel_task 0, id = 2, prio = 16
[0.030][1:2][INFO] LwIP's tcpip thread has task id 2
[0.030][1:1][INFO] TCP/IP initialized.
netif_set_ipaddr: netif address being changed
netif: IP address of interface ?? set to 192.168.28.2
netif: netmask of interface ?? set to 255.255.255.0
netif: GW address of interface ?? set/ 
```

This output has been captured from `/sys/hermit/log/isle0/log`, therefore it's not chronically sorted. Please note that timestamps help to find the beginning and end of the log.

Furthermore, LwIP still uses it's own logging facility which logs directly via `kprintf(...)`. I'm not sure if it's possible to make it use of the same logging as the kernel without changing it's source because it often uses multiple commands to print on the same line. This cannot be solved just by exchanging the `kprintf(...)` function with the hereby introduced macros. But this can be solved in follow-up PR.

PS: I also piggybacked a small typo fix as well as a new function to access the system uptime.