### PR TITLE
fix guest_size metadata for migration

### DIFF
--- a/tools/uhyve-x86_64.c
+++ b/tools/uhyve-x86_64.c
@@ -812,6 +812,11 @@ void *migration_handler(void *arg)
 		elf_entry,
 		full_checkpoint};
 
+	/* the guest size is calculated at the destination again */
+	if ((guest_size-KVM_32BIT_GAP_SIZE) >= KVM_32BIT_GAP_START) {
+		metadata.guest_size -= KVM_32BIT_GAP_SIZE;
+	}
+
 	res = send_data(&metadata, sizeof(migration_metadata_t));
       	fprintf(stderr, "Metadata sent! (%d bytes)\n", res);
 


### PR DESCRIPTION
If the guest exceeds KVM_32BIT_GAP_START we have to remove the
KVM_32BIT_GAP_SIZE from the guest_size since this is re-calculated at
the destination.